### PR TITLE
#38 support notifications

### DIFF
--- a/client/lib/application/src/application-form/application-form.js
+++ b/client/lib/application/src/application-form/application-form.js
@@ -1,6 +1,7 @@
 import BaseView from 'common/src/base-view';
 import Template from './application-form.hbs';
 import Flux from 'application/src/flux';
+import GlobalFlux from 'yourturn/src/flux';
 import {history} from 'backbone';
 import {constructLocalUrl} from 'common/src/data/services';
 import FetchResult from 'common/src/fetch-result';
@@ -111,9 +112,15 @@ class CreateApp extends BaseView {
             // and window.location is ugly and probably aborts the PUT request from before
             history.navigate(constructLocalUrl('kio', app.id), { trigger: true });
         })
-        .catch(e => {
+        .catch(() => {
             // FIXME with notification
-            console.error(e);
+            let verb = this.props.edit ? 'update' : 'create';
+            GlobalFlux
+            .getActions('notification')
+            .addNotification([
+                `Could not ${verb} application ${app.name}.`,
+                'error'
+            ]);
         });
     }
 

--- a/client/lib/common/asset/scss/yourturn/notification-bar.scss
+++ b/client/lib/common/asset/scss/yourturn/notification-bar.scss
@@ -1,0 +1,33 @@
+@import "../variables";
+
+.notificationBar {
+    position: fixed;
+    width: 100%;
+    z-index: 10;
+    ul {
+        margin: 0;
+        padding: 0;
+        list-style-type: none;
+        box-shadow: 0px 0px 5px $gray;
+        
+        li {
+            border-bottom: 1px solid $gray-light;
+            cursor: pointer;
+            padding: $padding-tiny;
+            &[data-notification-type="error"] {
+                background-color: $red;
+                color: $white;
+                &:before {
+                    font-family: 'FontAwesome';
+                    content: '\f06a';
+                    display: inline-block;
+                    margin-right: $padding-small;
+                }
+            }
+            &[data-notification-type="default"] {
+                background-color: $white;
+                color: $black;
+            }
+        }
+    }   
+}

--- a/client/lib/common/src/data/notification/notification-actions.js
+++ b/client/lib/common/src/data/notification/notification-actions.js
@@ -1,0 +1,18 @@
+import {Actions} from 'flummox';
+
+class NotificationActions extends Actions {
+
+    addNotification([message, type]) {
+        return [message, type];
+    }
+
+    removeNotification(id) {
+        return id;
+    }
+
+    removeNotificationsOlderThan(ms) {
+        return ms;
+    }
+}
+
+export default NotificationActions;

--- a/client/lib/common/src/data/notification/notification-store.js
+++ b/client/lib/common/src/data/notification/notification-store.js
@@ -1,0 +1,70 @@
+/** global Date */
+import {Store} from 'flummox';
+import _m from 'mori';
+
+var lastId = 1;
+
+class NotificationStore extends Store {
+    constructor(flux) {
+        super();
+
+        const notificationActions = flux.getActions('notification');
+
+        this.state = {
+            notifications: _m.vector()
+        };
+
+        this.register(notificationActions.addNotification, this.receiveNotification);
+        this.register(notificationActions.removeNotification, this.deleteNotification);
+        this.register(notificationActions.removeNotificationsOlderThan, this.deleteOldNotifications);
+    }
+
+    /**
+     * Saves notification.
+     *
+     * @param  {array} The first element is the message, the optional second the type.
+     */
+    receiveNotification([message, type]) {
+        lastId += 1;
+        this.setState({
+            notifications: _m.conj(this.state.notifications, _m.toClj({
+                type: type || 'default',
+                message: message,
+                id: lastId,
+                created: Date.now()
+            }))
+        });
+    }
+
+    /**
+     * Removes notification with `id`.
+     *
+     * @param  {number} id The ID of the notification
+     */
+    deleteNotification(id) {
+        this.setState({
+            notifications: _m.filter(n => _m.get(n, 'id') !== id, this.state.notifications)
+        });
+    }
+
+    /**
+     * Removes notifications older than `ms` ms.
+     *
+     * @param  {number} ms The age of the notification in ms.
+     */
+    deleteOldNotifications(ms) {
+        let now = Date.now();
+        this.setState({
+            notifications: _m.filter(n => _m.get(n, 'created') > (now - ms), this.state.notifications)
+        });
+    }
+
+    /**
+     * Returns all notifications.
+     */
+    getNotifications() {
+        return _m.toJs(this.state.notifications);
+    }
+}
+
+export default NotificationStore;

--- a/client/lib/yourturn/src/bootstrap.js
+++ b/client/lib/yourturn/src/bootstrap.js
@@ -1,9 +1,11 @@
 import $ from 'jquery';
 import {history} from 'backbone';
 import Sidebar from './sidebar/sidebar';
+import NotificationBar from './notification-bar/notification-bar';
 import Router from './router';
 import ResourceRouter from 'resource/src/router';
 import AppRouter from 'application/src/router';
+import Flux from './flux';
 
 import 'common/asset/scss/base.scss';
 import 'common/asset/scss/grid.scss';
@@ -12,9 +14,12 @@ import 'common/asset/scss/yourturn/yourturn.scss';
 let sidebar = new Sidebar();
 sidebar.render();
 
+let notifications = new NotificationBar();
+notifications.render();
 
 $(document).ready( () => {
-    $('#yourturn-sidebar').append( sidebar.$el );
+    $('#yourturn-sidebar').append(sidebar.$el);
+    $('body').prepend(notifications.$el);
     new Router();
     new ResourceRouter();
     new AppRouter();
@@ -22,6 +27,16 @@ $(document).ready( () => {
         pushState: true
     });
 });
+
+/**
+ * Continually dismiss old notifications.
+ */
+setInterval(() => {
+    Flux
+    .getActions('notification')
+    .removeNotificationsOlderThan(5000);
+}, 5000 );
+
 
 /**
  * To prevent a full page reload when someone clicks a link, we

--- a/client/lib/yourturn/src/flux.js
+++ b/client/lib/yourturn/src/flux.js
@@ -3,12 +3,18 @@ import {Flummox} from 'flummox';
 import SearchActions from 'common/src/data/search/search-actions';
 import SearchStore from 'common/src/data/search/search-store';
 
+import NotificationActions from 'common/src/data/notification/notification-actions';
+import NotificationStore from 'common/src/data/notification/notification-store';
+
 class YourturnFlux extends Flummox {
     constructor() {
         super();
 
         this.createActions( 'search', SearchActions );
         this.createStore( 'search', SearchStore, this );
+
+        this.createActions( 'notification', NotificationActions );
+        this.createStore( 'notification', NotificationStore, this );
     }
 }
 

--- a/client/lib/yourturn/src/notification-bar/notification-bar.hbs
+++ b/client/lib/yourturn/src/notification-bar/notification-bar.hbs
@@ -1,0 +1,8 @@
+{{#if notifications}}
+    <ul>
+        {{#each notifications}}
+            <li data-notification-id="{{this.id}}" data-notification-type="{{this.type}}">{{this.message}}</li>
+        {{/each}}
+    </ul>
+{{else}}
+{{/if}}

--- a/client/lib/yourturn/src/notification-bar/notification-bar.js
+++ b/client/lib/yourturn/src/notification-bar/notification-bar.js
@@ -1,0 +1,38 @@
+import $ from 'jquery';
+import BaseView from 'common/src/base-view';
+import Template from './notification-bar.hbs';
+import Flux from '../flux';
+import 'common/asset/scss/yourturn/notification-bar.scss';
+
+class NotificationBar extends BaseView {
+    constructor() {
+        this.store = Flux.getStore('notification');
+        this.actions = Flux.getActions('notification');
+        this.className = 'notificationBar';
+        this.events = {
+            'click li': 'dismissNotification'
+        };
+        super();
+    }
+
+    /**
+     * Removes the clicked notification from the store.
+     */
+    dismissNotification(evt) {
+        let id = parseInt($(evt.target).attr('data-notification-id'), 10);
+        this.actions.removeNotification(id);
+    }
+
+    update() {
+        this.data = {
+            notifications: this.store.getNotifications()
+        };
+    }
+
+    render() {
+        this.$el.html(Template(this.data));
+        return this;
+    }
+}
+
+export default NotificationBar;


### PR DESCRIPTION
Usage:

* Import the `notification` actions from yourturn’s Flux
* `notificationActions.addNotification([message, optionalType])`

By default notifications older than 5 secs will be cleaned up every 5 secs, so it will stay 5–10 sec. Click to dismiss.