### PR TITLE
ApplicationForm: Merge teams with account owners

### DIFF
--- a/client/lib/application/src/router.react.jsx
+++ b/client/lib/application/src/router.react.jsx
@@ -186,11 +186,17 @@ var ConnectedAppListHandler =
         }))(AppListHandler);
 
 const CreateAppFormHandler = (props) => {
-    const userTeams = props.userStore.getUserTeams().map(t => t.id),
+    const userTeams = props.userStore
+                        .getUserTeams()
+                        .map(t => t.id),
+        userAccounts = props.userStore
+                        .getUserCloudAccounts()
+                        .map(acc => acc.owner),
+        availableTeams = [...new Set([...userTeams, ...userAccounts])].sort(),
         applicationIds = props.kioStore.getApplications().map(a => a.id);
     return  <ApplicationForm
                 edit={false}
-                userTeams={userTeams}
+                userTeams={availableTeams}
                 applicationIds={applicationIds}
                 notificationActions={NOTIFICATION_ACTIONS}
                 kioActions={KIO_ACTIONS} />;
@@ -219,9 +225,15 @@ var ConnectedCreateAppFormHandler =
 
 const EditAppFormHandler = (props) => {
     const {applicationId} = props.params,
-          userTeams = props.userStore.getUserTeams().map(t => t.id),
           application = props.kioStore.getApplication(applicationId),
-          teamsAndPreviousValue = new Set([...userTeams, application.team_id]),
+          userTeams = props.userStore.
+                        getUserTeams()
+                        .map(t => t.id),
+          userAccounts = props.userStore
+                        .getUserCloudAccounts()
+                        .map(acc => acc.owner),
+          availableTeams = [...new Set([...userTeams, ...userAccounts])].sort(),
+          teamsAndPreviousValue = new Set([...availableTeams, application.team_id]),
           applicationIds = props.kioStore.getApplications().map(a => a.id);
 
     return <ApplicationForm


### PR DESCRIPTION
Fixes #491 

Previously only team IDs of the user were selectable. Now it's team IDs of the users plus owners (team IDs) of the accounts they have access to.