### PR TITLE
Fix error on search

### DIFF
--- a/client/lib/yourturn/src/search/search.jsx
+++ b/client/lib/yourturn/src/search/search.jsx
@@ -6,7 +6,7 @@ import 'common/asset/less/yourturn/search.less';
 
 const  SearchResult = (props) => {
     /*eslint-disable react/no-danger */
-    let body = <quote dangerouslySetInnerHTML={{__html: this.props.description}} />;
+    let body = <quote dangerouslySetInnerHTML={{__html: props.description}} />;
     /*eslint-disable react/no-danger */
 
     if (!props.link) {


### PR DESCRIPTION
Search.jsx is a pure component, but `this` is used inside. Doesn't work.