### PR TITLE
#487 forget to include less file loading in webpack for production

### DIFF
--- a/client/webpack.production.config.js
+++ b/client/webpack.production.config.js
@@ -89,7 +89,7 @@ module.exports = {
         ],
         loaders: [
             {test: /\.jsx?$/, exclude: /node_modules/, loaders: ['babel']},
-            {test: /\.less$/, exclude: /node_modules/, loader: ExtractTextPlugin.extract('css!autoprefixer!less')},
+            {test: /\.less$/, include: /node_modules\/react-widget|client/, loader: ExtractTextPlugin.extract('css!autoprefixer!less')},
             {test: /\.css$/, loader: ExtractTextPlugin.extract('css!autoprefixer')},
             {test: /\.(otf|eot|svg|ttf|woff|woff2)(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=8192&mimetype=application/font-woff'},
             {test: /\.(png|jpg|jpeg|gif)$/, loaders: ['url?limit=8192', 'img']}


### PR DESCRIPTION
react-widget library has less file in it which needs to be handled by appropriate loaders in webpack