### PR TITLE
Bail on error

### DIFF
--- a/client/Gulpfile.js
+++ b/client/Gulpfile.js
@@ -13,7 +13,10 @@ var fs = require('fs'),
     rename = require('gulp-rename'),
     webpack = require('webpack');
 
-process.on('uncaughtException', console.log.bind(console));
+process.on('uncaughtException', function(e) {
+    console.error(e);
+    process.exit(1);
+});
 
 var LODASH_FUNCS = [
         // own


### PR DESCRIPTION
Previously all build exceptions were caught and swallowed, leading to a green pipeline.