### PR TITLE
#507 Allow bucket name prefix gs://

### DIFF
--- a/client/lib/application/src/access-form/access-form.jsx
+++ b/client/lib/application/src/access-form/access-form.jsx
@@ -125,7 +125,7 @@ class AccessForm extends React.Component {
                                 onChange={this.updateBuckets.bind(this)}
                                 items={this.state.s3_buckets}
                                 markedItems={_.difference(this.state.s3_buckets, oauthConfig.s3_buckets)}
-                                pattern={'^[a-z0-9][a-z0-9\-\.]*[a-z0-9]$'} />
+                                pattern={'^(gs://)?[a-z0-9][a-z0-9\-\.]*[a-z0-9]$'} />
                         </div>
                         <div className='btn-group'>
                             <button


### PR DESCRIPTION
This makes it possible to add google cloud storage buckets using the
schema `gs://`.

Close #507

Related change in mint-storage: https://github.com/zalando-stups/mint-storage/pull/25

Eventually the UI should propably also mention Google cloud storage instead of just s3. But for now I think it should be as it is to not confuse most people who don't care about this *alpha* feature. These changes are tracked here: https://github.com/zalando-stups/mint-storage/issues/26