### PR TITLE
Add unique tokens counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "cd client && gulp lint",
     "format": "cd client && gulp format",
     "lodash": "cd client && gulp lodash",
-    "test-server": "cd server && npm install && mocha -r test/mocha-globals.js test/**/*.test.js",
+    "test-server": "cd server && npm install && mocha -r test/mocha-globals.js --recursive test",
+    "test-server-watch": "mocha --watch -r server/test/mocha-globals.js --recursive server/test",
     "test": "cd client && webpack --config webpack.test.config.js && mocha -r mocha-globals.js dist/test.js",
     "test-coverage": "cd client && webpack --config webpack.test.config.js && istanbul cover ../node_modules/mocha/bin/_mocha --report lcovonly -- -r mocha-globals.js dist/test.js && cat ./coverage/lcov.info | ../node_modules/coveralls/bin/coveralls.js",
     "test-coverage-local": "cd client && webpack --config webpack.test.config.js && istanbul cover ../node_modules/mocha/bin/_mocha --report html -- -r mocha-globals.js dist/test.js"

--- a/server/package.json
+++ b/server/package.json
@@ -15,20 +15,20 @@
   "homepage": "https://github.com/zalando-stups/yourturn",
   "dependencies": {
     "appdynamics": "4.1.10",
-    "newrelic": "1.24.0",
-    "winston": "2.1.1",
-    "express": "4.13.3",
-    "compression": "1.6.0",
-    "js-yaml": "3.4.6",
-    "node-tokens": "0.0.9",
     "bluebird": "3.1.1",
-    "redis": "2.4.2",
-    "superagent-bluebird-promise": "3.0.0",
-    "xml2js": "0.4.16",
     "camel-case": "1.2.2",
-    "shelljs": "0.5.3"
-  },
-  "devDependencies": {
-    "moment": "^2.14.1"
+    "compression": "1.6.0",
+    "express": "4.13.3",
+    "js-yaml": "3.4.6",
+    "lodash.isempty": "4.4.0",
+    "lodash.isfunction": "3.0.8",
+    "moment": "^2.14.1",
+    "newrelic": "1.24.0",
+    "node-tokens": "0.0.9",
+    "redis": "2.4.2",
+    "shelljs": "0.5.3",
+    "superagent-bluebird-promise": "3.0.0",
+    "winston": "2.1.1",
+    "xml2js": "0.4.16"
   }
 }

--- a/server/src/data/stores/distinct.js
+++ b/server/src/data/stores/distinct.js
@@ -1,0 +1,126 @@
+const bluebird = require('bluebird');
+const moment = require('moment');
+const winston = require('winston');
+
+const DEFAULT_EXPIRATION_TIME = moment.duration(1, 'week');
+const lastElement = arr => arr[arr.length - 1];
+
+const inMemoryStore = ({
+    keyExpiration = DEFAULT_EXPIRATION_TIME
+} = {}) => {
+    const store = new Map();
+
+    const cleanup = () => {
+        if (!keyExpiration) {
+            return;
+        }
+        const keysExpirationTime = moment().subtract(keyExpiration);
+        for (let [key, keyAdditionTime] of store) {
+            if (keyAdditionTime < keysExpirationTime) {
+                store.delete(key);
+            }
+        }
+    };
+
+    // TODO: find a way to use freeze here and not break tests
+    return Object.seal({
+        add(item) {
+            store.set(item, moment());
+            return Promise.resolve();
+        },
+        get size() {
+            cleanup();
+            return Promise.resolve(store.size);
+        },
+        get items() {
+            cleanup();
+            return Promise.resolve([...store.keys()]);
+        }
+    });
+};
+
+const redisStore = ({
+    redis,
+    key = 'distinct-items',
+    keyExpiration = DEFAULT_EXPIRATION_TIME
+} = {}) => {
+    if (!redis) {
+        throw new Error('redis should be not null');
+    }
+
+    const cleanup = () => {
+        if (!keyExpiration) {
+            return redis.multi();
+        } else {
+            const keysExpirationTime = moment().subtract(keyExpiration);
+            return redis.multi().zremrangebyscore(key, 0, keysExpirationTime.valueOf());
+        }
+    }
+
+    return Object.freeze({
+        add(item) {
+            // I don't wan't to swallow result here, but what should I return?
+            return redis.zaddAsync(key, moment().valueOf(),
+                JSON.stringify(item)).then(() => Promise.resolve());
+        },
+        get size() {
+            return cleanup().zcard(key).execAsync()
+                .then(lastElement);
+        },
+        get items() {
+            return cleanup().zrange(key, 0, -1).execAsync()
+                .then(lastElement)
+                .then(items => items.map(JSON.parse));
+        }
+    });
+};
+
+/**
+ * Would try to use fallbackStore as temporary storage for items while
+ * mainStore is not able to store items.
+ *
+ * All other behaviour is backed by mainStore only.
+ */
+const storeWithFallback = (mainStore, fallbackStore) => {
+    if (!mainStore) {
+        throw new Error('mainStore should be not null');
+    }
+    if (!fallbackStore) {
+        throw new Error('fallbackStore should be not null');
+    }
+
+    let mainStoreFailedLastTime = false;
+
+    return Object.freeze({
+        add(item) {
+            const continuation = mainStoreFailedLastTime ?
+                bluebird.map(fallbackStore.items, item => mainStore.add(item))
+                : Promise.resolve();
+
+            return continuation
+                .then(() => mainStore.add(item))
+                .then(() => {
+                    mainStoreFailedLastTime = false;
+                    return Promise.resolve();
+                })
+                .catch(mainError => {
+                    winston.info('main store failed to add item: %s', mainError);
+                    mainStoreFailedLastTime = true;
+                    return fallbackStore.add(item).catch(fallbackError =>
+                        Promise.reject([mainError, fallbackError]));
+                });
+        },
+        get size() {
+            return mainStore.size;
+        },
+        get items() {
+            return mainStore.items;
+        }
+    });
+}
+
+module.exports = {
+    inMemoryStore,
+    redisStore,
+    storeWithFallback
+};

--- a/server/src/metrics/index.js
+++ b/server/src/metrics/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const bluebird = require('bluebird');
 const isFunction = require('lodash.isfunction');
 const winston = require('winston');
@@ -22,20 +24,21 @@ const cachedProvider = (provider, defaultResult) => {
         })
 };
 
-const report = ({
-    providers = {}
-} = {}) => Object.freeze({
-    generate() {
-        return bluebird.props(Object.keys(providers || {})
-            .reduce((report, name) => {
-                const provider = providers[name];
-                report[name] = new Promise(resolve => {
-                    resolve(isFunction(provider) ? provider() : provider);
-                });
-                return report;
-            }, {}));
-    },
-});
+const report = (options) => {
+    const providers = (options || {}).providers || {};
+    return Object.freeze({
+        generate() {
+            return bluebird.props(Object.keys(providers)
+                .reduce((report, name) => {
+                    const provider = providers[name];
+                    report[name] = new Promise(resolve => {
+                        resolve(isFunction(provider) ? provider() : provider);
+                    });
+                    return report;
+                }, {}));
+        },
+    });
+};
 
 module.exports = {
     report,

--- a/server/src/metrics/index.js
+++ b/server/src/metrics/index.js
@@ -1,0 +1,43 @@
+const bluebird = require('bluebird');
+const isFunction = require('lodash.isfunction');
+const winston = require('winston');
+
+const cachedProvider = (provider, defaultResult) => {
+    if (!provider) {
+        throw new Error('provider should be not null');
+    }
+    if (defaultResult === undefined || defaultResult === null) {
+        throw new Error('defaultResult should be not null');
+    }
+
+    let cachedResult = defaultResult;
+    return () => new Promise(resolve => resolve(isFunction(provider) ? provider() : provider))
+        .then(result => {
+            cachedResult = result;
+            return result;
+        })
+        .catch(err => {
+            winston.error('provider failed: %s', err);
+            return cachedResult;
+        })
+};
+
+const report = ({
+    providers = {}
+} = {}) => Object.freeze({
+    generate() {
+        return bluebird.props(Object.keys(providers || {})
+            .reduce((report, name) => {
+                const provider = providers[name];
+                report[name] = new Promise(resolve => {
+                    resolve(isFunction(provider) ? provider() : provider);
+                });
+                return report;
+            }, {}));
+    },
+});
+
+module.exports = {
+    report,
+    cachedProvider
+};

--- a/server/src/middleware/oauth.js
+++ b/server/src/middleware/oauth.js
@@ -27,6 +27,7 @@ module.exports = function(req, res, next) {
             access_token: token
         })
         .then(tokeninfo => {
+            req.tokeninfo = tokeninfo.body;
             if (tokeninfo.body.realm === '/employees' ||
                 tokeninfo.body.realm === '/services') {
                 return next();

--- a/server/src/middleware/unique-logins.js
+++ b/server/src/middleware/unique-logins.js
@@ -1,0 +1,15 @@
+const winston = require('winston');
+const isEmpty = require('lodash.isempty');
+
+module.exports = store => {
+    return (req, res, next) => {
+        if (!isEmpty(req.tokeninfo)) {
+            const {uid, realm} = req.tokeninfo;
+            store.add(`${realm}/${uid}`).catch(err => {
+                winston.error('failed to store unique login: %s', err);
+            });
+        }
+
+        next();
+    }
+};

--- a/server/src/middleware/unique-logins.js
+++ b/server/src/middleware/unique-logins.js
@@ -4,7 +4,8 @@ const isEmpty = require('lodash.isempty');
 module.exports = store => {
     return (req, res, next) => {
         if (!isEmpty(req.tokeninfo)) {
-            const {uid, realm} = req.tokeninfo;
+            const uid = req.tokeninfo.uid;
+            const realm = req.tokeninfo.realm;
             store.add(`${realm}/${uid}`).catch(err => {
                 winston.error('failed to store unique login: %s', err);
             });

--- a/server/test/data/stores/distinct.test.js
+++ b/server/test/data/stores/distinct.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const sinon = require('sinon');
 const redis = require('redis');
 const moment = require('moment');
@@ -200,12 +202,15 @@ describe('stores/distinct', () => {
                         main.items,
                         fallback.items
                     ]))
-                    .then(([storeItems, mainItems, fallbackItems]) => {
+                    .then(res => {
+                        const storeItems = res[0];
+                        const mainItems = res[1];
+                        const fallbackItems = res[2];
+
                         expect(storeItems).to.have.members([42]);
                         expect(mainItems).to.have.members([42]);
                         expect(fallbackItems).to.be.empty;
-                    })
-
+                    });
             });
 
             it('should add items to fallback store if main store fails', () => {
@@ -222,7 +227,11 @@ describe('stores/distinct', () => {
                         main.items,
                         fallback.items
                     ]))
-                    .then(([storeItems, mainItems, fallbackItems]) => {
+                    .then(res => {
+                        const storeItems = res[0];
+                        const mainItems = res[1];
+                        const fallbackItems = res[2];
+
                         expect(storeItems).to.be.empty;
                         expect(mainItems).to.be.empty;
                         expect(fallbackItems).to.have.members([42]);
@@ -248,7 +257,11 @@ describe('stores/distinct', () => {
                         main.items,
                         fallback.items
                     ]))
-                    .then(([storeItems, mainItems, fallbackItems]) => {
+                    .then(res => {
+                        const storeItems = res[0];
+                        const mainItems = res[1];
+                        const fallbackItems = res[2];
+
                         expect(storeItems).to.have.members([42, 'foo', 'bar']);
                         expect(mainItems).to.have.members([42, 'foo', 'bar']);
                         expect(fallbackItems).to.have.members([42, 'foo']);
@@ -267,7 +280,10 @@ describe('stores/distinct', () => {
                     .returns(Promise.reject(new Error('fallback error')));
 
                 return store.add(42)
-                    .catch(([mainError, fallbackError]) => {
+                    .catch(res => {
+                        const mainError = res[0];
+                        const fallbackError = res[1];
+
                         expect(mainError).to.be.an('error');
                         expect(mainError.message).to.equal('main error');
                         expect(fallbackError).to.be.an('error');

--- a/server/test/data/stores/distinct.test.js
+++ b/server/test/data/stores/distinct.test.js
@@ -1,0 +1,279 @@
+const sinon = require('sinon');
+const redis = require('redis');
+const moment = require('moment');
+const bluebird = require('bluebird');
+
+const stores = require('../../../src/data/stores/distinct');
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('stores/distinct', () => {
+    describe('in-memory', () => {
+        describe('#add', () => {
+            it('should add any item', () => {
+                const store = stores.inMemoryStore({
+                    keyExpiration: null
+                });
+
+                return Promise.all([
+                    store.add(42),
+                    store.add('foo'),
+                    store.add({ key: 'value' })
+                ]);
+            });
+        });
+
+        describe('#size', () => {
+            it('should return 0 if no items where added', () => {
+                const store = stores.inMemoryStore();
+
+                return store.size.then(size => {
+                    expect(size).to.equal(0);
+                });
+            });
+
+            it('should return count of all items if there are no expiration', () => {
+                const store = stores.inMemoryStore({
+                    keyExpiration: null
+                });
+
+                return Promise.all([store.add(42), store.add('foo')])
+                    .then(() => store.size)
+                    .then(size => {
+                        expect(size).to.equal(2);
+                    });
+            });
+
+            it('should return count of all non-expired items', () => {
+                const store = stores.inMemoryStore({
+                    keyExpiration: moment.duration(100, 'ms')
+                });
+
+                return store.add(42)
+                    .then(() => delay(150))
+                    .then(() => store.add('foo'))
+                    .then(() => store.size)
+                    .then(size => {
+                        expect(size).to.equal(1);
+                    });
+            });
+
+            it('should return 0 if all items have expired', () => {
+                const store = stores.inMemoryStore({
+                    keyExpiration: moment.duration(100, 'ms')
+                });
+
+                return store.add(42)
+                    .then(() => store.add('foo'))
+                    .then(() => delay(150))
+                    .then(() => store.size)
+                    .then(size => {
+                        expect(size).to.equal(0);
+                    });
+            });
+        });
+
+        describe('#items', () => {
+            it('should return empty array if no items were added', () => {
+                const store = stores.inMemoryStore();
+
+                return store.items.then(items => {
+                    expect(items).to.be.empty;
+                });
+            });
+
+            it('should return all items if there are no expiration', () => {
+                const store = stores.inMemoryStore({
+                    keyExpiration: null
+                });
+
+                return Promise.all([
+                    store.add(42),
+                    store.add('foo')
+                ])
+                    .then(() => store.items)
+                    .then(items => {
+                        expect(items).to.have.members([42, 'foo']);
+                    });
+            });
+
+            it('should return all non-expirated items', () => {
+                const store = stores.inMemoryStore({
+                    keyExpiration: moment.duration(100, 'ms')
+                });
+
+                return store.add(42)
+                    .then(() => delay(150))
+                    .then(() => store.add('foo'))
+                    .then(() => store.items)
+                    .then(items => {
+                        expect(items).to.have.members(['foo']);
+                    });
+            });
+
+            it('should return empty array if all items have expired', () => {
+                const store = stores.inMemoryStore({
+                    keyExpiration: moment.duration(100, 'ms')
+                });
+
+                return store.add(42)
+                    .then(() => store.add('foo'))
+                    .then(() => delay(150))
+                    .then(() => store.items)
+                    .then(items => {
+                        expect(items).to.be.empty;
+                    });
+            });
+        });
+    });
+
+    // First I've started with sinon stubs and all that stuff, but ended
+    // up mocking entire responses which is stupid and have no relation
+    // to code under test
+    describe('redis', () => {
+        let redisClient;
+
+        before(() => {
+            bluebird.promisifyAll(redis.RedisClient.prototype);
+            bluebird.promisifyAll(redis.Multi.prototype);
+        });
+
+        beforeEach(() => {
+            redisClient = sinon.createStubInstance(redis.RedisClient);
+            redisClient.multi
+                .withArgs()
+                .returnsThis();
+        });
+
+        describe('#items', () => {
+            it('should store encoded and return decoded items', () => {
+                const store = stores.redisStore({
+                    redis: redisClient,
+                    keyExpiration: null
+                });
+
+                const first = 42;
+                const second = '42';
+                const third = { key: 'value' };
+
+                redisClient.zaddAsync
+                    .withArgs('distinct-items', sinon.match.number, JSON.stringify(first))
+                    .returns(Promise.resolve())
+                    .withArgs('distinct-items', sinon.match.number, JSON.stringify(second))
+                    .returns(Promise.resolve())
+                    .withArgs('distinct-items', sinon.match.number, JSON.stringify(third))
+                    .returns(Promise.resolve());
+                redisClient.zrange
+                    .withArgs('distinct-items', 0, -1)
+                    .returnsThis();
+                redisClient.execAsync
+                    .returns(Promise.resolve([0, [
+                        JSON.stringify(first),
+                        JSON.stringify(second),
+                        JSON.stringify(third)
+                    ]]));
+
+                return Promise.all([
+                    store.add(first),
+                    store.add(second),
+                    store.add(third)
+                ])
+                    .then(() => store.items)
+                    .then(items => {
+                        expect(items).to.eql([42, '42', { key: 'value' }]);
+                    });
+            });
+        });
+    });
+
+    describe('with-fallback', () => {
+        describe('#add', () => {
+            it('should add items to main store first', () => {
+                const main = stores.inMemoryStore();
+                const fallback = stores.inMemoryStore();
+
+                const store = stores.storeWithFallback(main, fallback);
+
+                return store.add(42)
+                    .then(() => Promise.all([
+                        store.items,
+                        main.items,
+                        fallback.items
+                    ]))
+                    .then(([storeItems, mainItems, fallbackItems]) => {
+                        expect(storeItems).to.have.members([42]);
+                        expect(mainItems).to.have.members([42]);
+                        expect(fallbackItems).to.be.empty;
+                    })
+
+            });
+
+            it('should add items to fallback store if main store fails', () => {
+                const main = Object.create(stores.inMemoryStore());
+                const fallback = stores.inMemoryStore();
+
+                const store = stores.storeWithFallback(main, fallback);
+
+                sinon.stub(main, 'add').returns(Promise.reject());
+
+                return store.add(42)
+                    .then(() => Promise.all([
+                        store.items,
+                        main.items,
+                        fallback.items
+                    ]))
+                    .then(([storeItems, mainItems, fallbackItems]) => {
+                        expect(storeItems).to.be.empty;
+                        expect(mainItems).to.be.empty;
+                        expect(fallbackItems).to.have.members([42]);
+                    })
+            });
+
+            it('should add items to main store from fallback store when main'
+                + ' is avaliable again', () => {
+                const main = stores.inMemoryStore();
+                const fallback = stores.inMemoryStore();
+
+                const store = stores.storeWithFallback(main, fallback);
+
+                sinon.stub(main, 'add').returns(Promise.reject());
+
+                return Promise.all([store.add(42), store.add('foo')])
+                    .then(() => {
+                        main.add.restore();
+                        return store.add('bar');
+                    })
+                    .then(() => Promise.all([
+                        store.items,
+                        main.items,
+                        fallback.items
+                    ]))
+                    .then(([storeItems, mainItems, fallbackItems]) => {
+                        expect(storeItems).to.have.members([42, 'foo', 'bar']);
+                        expect(mainItems).to.have.members([42, 'foo', 'bar']);
+                        expect(fallbackItems).to.have.members([42, 'foo']);
+                    });
+            });
+
+            it('would reject with both stores errors if they fail', () => {
+                const main = stores.inMemoryStore();
+                const fallback = stores.inMemoryStore();
+
+                const store = stores.storeWithFallback(main, fallback)
+
+                sinon.stub(main, 'add')
+                    .returns(Promise.reject(new Error('main error')));
+                sinon.stub(fallback, 'add')
+                    .returns(Promise.reject(new Error('fallback error')));
+
+                return store.add(42)
+                    .catch(([mainError, fallbackError]) => {
+                        expect(mainError).to.be.an('error');
+                        expect(mainError.message).to.equal('main error');
+                        expect(fallbackError).to.be.an('error');
+                        expect(fallbackError.message).to.equal('fallback error');
+                    });
+            });
+        });
+    });
+});

--- a/server/test/metrics/index.test.js
+++ b/server/test/metrics/index.test.js
@@ -1,0 +1,158 @@
+const sinon = require('sinon');
+
+const metrics = require('../../src/metrics');
+
+describe('metrics', () => {
+    describe('report', () => {
+        describe('#generate', () => {
+            it('would return empty report if there are no reporters', () => {
+                const report = metrics.report();
+                return report.generate().then(report => {
+                    expect(report).to.be.empty;
+                });
+            });
+
+            it('would return empty report if providers are null', () => {
+                const report = metrics.report({
+                    providers: null
+                });
+                return report.generate().then(report => {
+                    expect(report).to.be.empty;
+                });
+            });
+
+            it('would return report with values for providers of all kind', () => {
+                const report = metrics.report({
+                    providers: {
+                        simple: 42,
+                        'function-call': () => 42,
+                        'function-call-2': (counter => () => ++counter)(41)
+                    }
+                });
+
+                return report.generate()
+                    .then(report => {
+                    expect(report).to.eql({
+                        simple: 42,
+                        'function-call': 42,
+                        'function-call-2': 42
+                    });
+                });
+            });
+
+            it('would wrap sync provider Error', () => {
+                const report = metrics.report({
+                    providers: {
+                        'bad-boy': () => {
+                            throw new Error('oops');
+                        }
+                    }
+                });
+
+                return report.generate()
+                    .then(() => {
+                        throw new Error('have not expected you here');
+                    })
+                    .catch(err => {
+                        expect(err).to.be.an('error');
+                        expect(err.message).to.equal('oops');
+                    });
+            });
+        });
+    });
+
+    describe('cachedProvider', () => {
+        it('would throw if no provider is provided', () => {
+            expect(() => {
+                metrics.cachedProvider();
+            }).to.throw(Error, 'provider should be not null');
+        });
+
+        it('would throw if no defaultValue is provided', () => {
+            expect(() => {
+                metrics.cachedProvider(() => {});
+            }).to.throw(Error, 'defaultResult should be not null');
+        });
+
+        it('would return provider itselt if provider is not a function', () => {
+            const provider = metrics.cachedProvider({
+                foo: 'good'
+            }, {
+                foo: 'bad'
+            });
+
+            return provider().then(result => {
+                expect(result).to.eql({
+                    foo: 'good'
+                });
+            });
+        });
+
+        it('would return default result if provider failes on first run', () => {
+            const provider = metrics.cachedProvider(() => Promise.reject(), 42);
+
+            return provider().then(result => {
+                expect(result).to.equal(42);
+            })
+        });
+
+        it('would return cached result if provider runned at least once', () => {
+            const provider = sinon.stub();
+            const cached = metrics.cachedProvider(provider, 0);
+
+            provider.onFirstCall().returns(42)
+                    .onSecondCall().returns(Promise.reject());
+
+            return cached().then(result => {
+                expect(result).to.equal(42);
+                return cached();
+            })
+            .then(result => {
+                expect(result).to.equal(42);
+            });
+        });
+
+        it('would update cached result after last successful provider run', () => {
+            const provider = sinon.stub();
+            const cached = metrics.cachedProvider(provider, 0);
+
+            provider.onFirstCall().returns(42)
+                    .onSecondCall().returns(Promise.reject())
+                    .onThirdCall().returns(9000);
+
+            return cached()
+            .then(result => {
+                expect(result).to.equal(42);
+                return cached();
+            })
+            .then(result => {
+                expect(result).to.equal(42);
+                return cached();
+            })
+            .then(result => {
+                expect(result).to.equal(9000);
+            });
+        });
+
+        it('would return bad results if they are sucessfully resolve', () => {
+            const provider = metrics.cachedProvider(() => new Error('oops'), {
+                something: 'good'
+            });
+
+            return provider().then(result => {
+                expect(result).to.be.an('error');
+                expect(result.message).to.equal('oops');
+            });
+        });
+
+        it('would return catch even error throw in providers', () => {
+            const provider = metrics.cachedProvider(() => {
+                throw new Error('oops');
+            }, 42);
+
+            return provider().then(result => {
+                expect(result).to.equal(42);
+            });
+        });
+    });
+});

--- a/server/test/middleware/unique-logins.test.js
+++ b/server/test/middleware/unique-logins.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const sinon = require('sinon');
 const winston = require('winston');
 

--- a/server/test/middleware/unique-logins.test.js
+++ b/server/test/middleware/unique-logins.test.js
@@ -1,0 +1,63 @@
+const sinon = require('sinon');
+const winston = require('winston');
+
+const uniqueLogins = require('../../src/middleware/unique-logins');
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('middleware/unique-logins', () => {
+    let store, storeMock, next;
+
+    before(() => {
+        store = {
+            add(item) { throw new Error('unexpected call'); },
+            get size() { throw new Error('unexpected call'); },
+            get items() { throw new Error('unexpected call'); }
+        };
+    });
+
+    beforeEach(() => {
+        storeMock = sinon.mock(store);
+        next = sinon.spy();
+    });
+
+    it('should do nothing if there is no tokeninfo in request', () => {
+        const middleware = uniqueLogins(store);
+        middleware({}, {}, next);
+
+        return delay(100)
+            .then(() => {
+                expect(next.calledOnce).to.be.true;
+            });
+    });
+
+    it('should do nothing if tokeninfo is in request but is empty', () => {
+        const middleware = uniqueLogins(store);
+        middleware({ tokeninfo: {} }, {}, next);
+
+        return delay(100)
+            .then(() => {
+                expect(next.calledOnce).to.be.true;
+            })
+    });
+
+    it('should add token to store if tokeninfo is in request', () => {
+        const middleware = uniqueLogins(store);
+
+        storeMock.expects('add').once().withExactArgs('/realm/uid')
+            .returns(Promise.resolve());
+
+        middleware({
+            tokeninfo: {
+                realm: '/realm',
+                uid: 'uid'
+            }
+        }, {}, next);
+
+        return delay(100)
+            .then(() => {
+                storeMock.verify();
+                expect(next.calledOnce).to.be.true;
+            });
+    });
+});


### PR DESCRIPTION
Closes #515

Overview:

Unique tokens are saved to store and their count is exposed by metrics reporter at custom endpoint.

Details:
- `store` is cache-like structure with 2 implementations:
  - `in-memory` is based on `ES6` Map
  - `redis` is based on Redis sorted set where key is token and score is timestamp in ms

TODO:
- [ ] - separate issue for `oauth` middleware?
