### PR TITLE
Removing access_token from query param

### DIFF
--- a/client/lib/common/src/data/user/user-actions.js
+++ b/client/lib/common/src/data/user/user-actions.js
@@ -11,8 +11,8 @@ function fetchTokenInfo() {
     }
     return request
             .get(`${ENV_DEVELOPMENT ? 'http://localhost:5006' : ''}/tokeninfo`)
-            .query({
-                access_token: token
+            .set({
+                "Authorization": `Bearer ${token}`
             })
             .accept('json')
             .exec()

--- a/client/lib/common/src/data/user/user-actions.js
+++ b/client/lib/common/src/data/user/user-actions.js
@@ -12,7 +12,7 @@ function fetchTokenInfo() {
     return request
             .get(`${ENV_DEVELOPMENT ? 'http://localhost:5006' : ''}/tokeninfo`)
             .set({
-                "Authorization": `Bearer ${token}`
+                'Authorization': `Bearer ${token}`
             })
             .accept('json')
             .exec()

--- a/client/lib/common/src/data/user/user-actions.js
+++ b/client/lib/common/src/data/user/user-actions.js
@@ -10,8 +10,8 @@ function fetchTokenInfo() {
         return Promise.reject();
     }
     return request
-            .post(`${ENV_DEVELOPMENT ? 'http://localhost:5006' : ''}/tokeninfo`)
-            .send({
+            .get(`${ENV_DEVELOPMENT ? 'http://localhost:5006' : ''}/tokeninfo`)
+            .query({
                 access_token: token
             })
             .accept('json')

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -26,9 +26,11 @@ pipeline:
           time docker build -t ${IMAGE}-test:${CDP_BUILD_VERSION} \
                             -t ${IMAGE}:${CDP_BUILD_VERSION} .
 
-          docker push ${IMAGE}-test:${CDP_BUILD_VERSION}
 
           IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
           if [[ ${CDP_TARGET_BRANCH} == "master" && ${IS_PR_BUILD} != "true" ]]; then
               docker push ${IMAGE}:${CDP_BUILD_VERSION}
+          else
+              docker push ${IMAGE}-test:${CDP_BUILD_VERSION}
           fi
+

--- a/server/mocks/5006-tokeninfo.js
+++ b/server/mocks/5006-tokeninfo.js
@@ -20,10 +20,11 @@ server.use(function(req, res, next) {
 });
 
 server.get('/tokeninfo', function(req,res) {
-    if (!req.query.access_token) {
+    var accessToken = req.get("authorization");
+    if (!accessToken) {
         return res.status(400).send();
     }
-    tokeninfo.access_token = req.query.access_token;
+    tokeninfo.access_token = accessToken;
     res.status(200).send(tokeninfo);
 });
 

--- a/server/mocks/5006-tokeninfo.js
+++ b/server/mocks/5006-tokeninfo.js
@@ -1,5 +1,4 @@
 var express = require('express'),
-    bodyParser = require('body-parser'),
     server = express();
 
 var tokeninfo = {
@@ -19,14 +18,12 @@ server.use(function(req, res, next) {
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
     next();
 });
-server.use(bodyParser.json())
 
-
-server.post('/tokeninfo', function(req,res) {
-    if (!req.body.access_token) {
+server.get('/tokeninfo', function(req,res) {
+    if (!req.query.access_token) {
         return res.status(400).send();
     }
-    tokeninfo.access_token = req.body.access_token;
+    tokeninfo.access_token = req.query.access_token;
     res.status(200).send(tokeninfo);
 });
 

--- a/server/src/middleware/oauth.js
+++ b/server/src/middleware/oauth.js
@@ -23,7 +23,7 @@ module.exports = function(req, res, next) {
     request
         .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
         .set({
-            "Authentication": accessToken
+            "Authorization": accessToken
           })
         .then(tokeninfo => {
             req.tokeninfo = tokeninfo.body;

--- a/server/src/middleware/oauth.js
+++ b/server/src/middleware/oauth.js
@@ -23,7 +23,7 @@ module.exports = function(req, res, next) {
     // verify token
     request
         .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
-        .query({
+        .set({
             access_token: token
         })
         .then(tokeninfo => {

--- a/server/src/middleware/oauth.js
+++ b/server/src/middleware/oauth.js
@@ -1,37 +1,38 @@
-var request = require("superagent-bluebird-promise");
+var request = require('superagent-bluebird-promise');
 
 function sendGenericError(res) {
-  return res
-    .status(401)
-    .set("WWW-Authenticate", "OAuth2")
-    .send();
+    return res
+            .status(401)
+            .set('WWW-Authenticate', 'OAuth2')
+            .send();
 }
 
 /**
  * OAuth 2 middleware.
  */
 module.exports = function(req, res, next) {
-  // if there is no token, respond with 401
-  if (!req.headers.authorization || !req.headers.authorization.startsWith("Bearer ")) {
-    return sendGenericError(res);
-  }
+    // if there is no token, respond with 401
+    if (!req.headers.authorization ||
+        !req.headers.authorization.startsWith('Bearer ')) {
+        return sendGenericError(res);
+    }
 
-  var header = req.headers.authorization,
-    token = header.substring("Bearer ".length);
+    var header = req.headers.authorization,
+        token = header.substring('Bearer '.length);
 
-  // verify token
-  request
-    .post(process.env.YTENV_OAUTH_TOKENINFO_URL)
-    .accept("json")
-    .send({
-      access_token: req.query.access_token
-    })
-    .then(tokeninfo => {
-      req.tokeninfo = tokeninfo.body;
-      if (tokeninfo.body.realm === "/employees" || tokeninfo.body.realm === "/services") {
-        return next();
-      }
-      return sendGenericError(res);
-    })
-    .catch(err => sendGenericError(res));
+    // verify token
+    request
+        .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
+        .query({
+            access_token: token
+        })
+        .then(tokeninfo => {
+            req.tokeninfo = tokeninfo.body;
+            if (tokeninfo.body.realm === '/employees' ||
+                tokeninfo.body.realm === '/services') {
+                return next();
+            }
+            return sendGenericError(res);
+        })
+        .catch(err => sendGenericError(res));
 };

--- a/server/src/middleware/oauth.js
+++ b/server/src/middleware/oauth.js
@@ -17,7 +17,7 @@ module.exports = function(req, res, next) {
         return sendGenericError(res);
     }
 
-    var accessToken = req.get("authorization");
+    var accessToken = req.get("Authorization");
 
     // verify token
     request

--- a/server/src/middleware/oauth.js
+++ b/server/src/middleware/oauth.js
@@ -17,15 +17,14 @@ module.exports = function(req, res, next) {
         return sendGenericError(res);
     }
 
-    var header = req.headers.authorization,
-        token = header.substring('Bearer '.length);
+    var accessToken = req.get("authorization");
 
     // verify token
     request
         .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
         .set({
-            access_token: token
-        })
+            "Authentication": accessToken
+          })
         .then(tokeninfo => {
             req.tokeninfo = tokeninfo.body;
             if (tokeninfo.body.realm === '/employees' ||

--- a/server/src/routes/tokeninfo.js
+++ b/server/src/routes/tokeninfo.js
@@ -3,6 +3,7 @@ var winston = require("winston"),
 
 function info(req, res) {
   var accessToken = req.get("authorization");
+  console.log("accessToken", accessToken);
   request
     .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
     .accept("json")

--- a/server/src/routes/tokeninfo.js
+++ b/server/src/routes/tokeninfo.js
@@ -4,7 +4,6 @@ var winston = require("winston"),
 function info(req, res) {
   var accessToken = req.get("authorization");
   accessToken
-  console.log("accessToken", accessToken);
   request
     .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
     .accept("json")
@@ -12,8 +11,6 @@ function info(req, res) {
       "Authorization": accessToken
     })
     .then(response => {
-
-      console.log("response", response);
       return res
         .status(200)
         .type("json")
@@ -21,7 +18,6 @@ function info(req, res) {
     }
     )
     .catch(err => {
-      console.log("err", err);
       if (err.status !== 400) {
         winston.error("Could not GET /tokeninfo: %d %s", err.status || 0, err.message);
       }

--- a/server/src/routes/tokeninfo.js
+++ b/server/src/routes/tokeninfo.js
@@ -1,29 +1,27 @@
-var winston = require("winston"),
-  request = require("superagent-bluebird-promise");
+var winston = require('winston'),
+    request = require('superagent-bluebird-promise');
 
 function info(req, res) {
-  request
-    .post(process.env.YTENV_OAUTH_TOKENINFO_URL)
-    .accept("json")
-    .send({
-      access_token: req.query.access_token
-    })
-    .then(response =>
-      res
-        .status(200)
-        .type("json")
-        .send(response.text)
-    )
-    .catch(err => {
-      if (err.status !== 400) {
-        // log error on tokeninfo only if it's not
-        // because of an invalid token
-        winston.error("Could not GET /tokeninfo: %d %s", err.status || 0, err.message);
-      }
-      return res.status(err.status || 0).send(err);
-    });
-}
+    request
+        .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
+        .accept('json')
+        .query({
+            access_token: req.query.access_token
+        })
+        .then(response => res
+                            .status(200)
+                            .type('json')
+                            .send(response.text))
+        .catch(err => {
+            if (err.status !== 400) {
+                // log error on tokeninfo only if it's not
+                // because of an invalid token
+                winston.error('Could not GET /tokeninfo: %d %s', err.status || 0, err.message);
+            }
+            return res.status(err.status || 0).send(err);
+        });
+};
 
 module.exports = {
-  info
+    info
 };

--- a/server/src/routes/tokeninfo.js
+++ b/server/src/routes/tokeninfo.js
@@ -10,13 +10,17 @@ function info(req, res) {
     .query({
       access_token: accessToken
     })
-    .then(response =>
-      res
+    .then(response => {
+
+      console.log("response", response);
+      return res
         .status(200)
         .type("json")
         .send(response.text)
+    }
     )
     .catch(err => {
+      console.log("response", response);
       if (err.status !== 400) {
         winston.error("Could not GET /tokeninfo: %d %s", err.status || 0, err.message);
       }

--- a/server/src/routes/tokeninfo.js
+++ b/server/src/routes/tokeninfo.js
@@ -9,7 +9,7 @@ function info(req, res) {
     .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
     .accept("json")
     .set({
-      "Authentication": accessToken
+      "Authorization": accessToken
     })
     .then(response => {
 

--- a/server/src/routes/tokeninfo.js
+++ b/server/src/routes/tokeninfo.js
@@ -20,7 +20,7 @@ function info(req, res) {
     }
     )
     .catch(err => {
-      console.log("response", response);
+      console.log("err", err);
       if (err.status !== 400) {
         winston.error("Could not GET /tokeninfo: %d %s", err.status || 0, err.message);
       }

--- a/server/src/routes/tokeninfo.js
+++ b/server/src/routes/tokeninfo.js
@@ -3,12 +3,13 @@ var winston = require("winston"),
 
 function info(req, res) {
   var accessToken = req.get("authorization");
+  accessToken
   console.log("accessToken", accessToken);
   request
     .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
     .accept("json")
-    .query({
-      access_token: accessToken
+    .set({
+      "Authentication": accessToken
     })
     .then(response => {
 

--- a/server/src/routes/tokeninfo.js
+++ b/server/src/routes/tokeninfo.js
@@ -1,27 +1,28 @@
-var winston = require('winston'),
-    request = require('superagent-bluebird-promise');
+var winston = require("winston"),
+  request = require("superagent-bluebird-promise");
 
 function info(req, res) {
-    request
-        .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
-        .accept('json')
-        .query({
-            access_token: req.query.access_token
-        })
-        .then(response => res
-                            .status(200)
-                            .type('json')
-                            .send(response.text))
-        .catch(err => {
-            if (err.status !== 400) {
-                // log error on tokeninfo only if it's not
-                // because of an invalid token
-                winston.error('Could not GET /tokeninfo: %d %s', err.status || 0, err.message);
-            }
-            return res.status(err.status || 0).send(err);
-        });
-};
+  var accessToken = req.get("authorization");
+  request
+    .get(process.env.YTENV_OAUTH_TOKENINFO_URL)
+    .accept("json")
+    .query({
+      access_token: accessToken
+    })
+    .then(response =>
+      res
+        .status(200)
+        .type("json")
+        .send(response.text)
+    )
+    .catch(err => {
+      if (err.status !== 400) {
+        winston.error("Could not GET /tokeninfo: %d %s", err.status || 0, err.message);
+      }
+      return res.status(err.status || 0).send(err);
+    });
+}
 
 module.exports = {
-    info
+  info
 };

--- a/server/src/yourturn.js
+++ b/server/src/yourturn.js
@@ -61,7 +61,7 @@ server.get('/teams/:teamId', routes.team.team);
 server.get('/users/:userId', oauth, uniqueLogins(store), routes.user.detail);
 server.get('/users/:userId/teams', routes.user.teams)
 server.get('/users/:userId/accounts', routes.user.accounts);
-server.post('/tokeninfo', routes.tokeninfo.info);
+server.get('/tokeninfo', routes.tokeninfo.info);
 server.get('/metrics', (req, res) => {
     report.generate().then(report => {
         res.json(report);


### PR DESCRIPTION
**Changes:**
- the rest call from the client (Yourturn Frontend) sends the token as authentication header instead of query parameter
- the route `/tokeninfo` and the middleware `oauth` send the `access_token` as authorization header instead of query parameter