### PR TITLE
Add a `Support` to Application Form and Detail.

### DIFF
--- a/client/lib/application/src/application-detail/application-detail.jsx
+++ b/client/lib/application/src/application-detail/application-detail.jsx
@@ -130,6 +130,14 @@ export default function ApplicationDetail({applicationId, application, editable,
                             </td>
                         </tr>
                         <tr>
+                            <th>Support</th>
+                            <td>
+                                <a href={application.support_url}>
+                                    {application.support_url}
+                                </a>
+                            </td>
+                        </tr>
+                        <tr>
                             <th>Specification Type</th>
                             <td>
                                 {application.specification_type}

--- a/client/lib/application/src/application-detail/placeholder.jsx
+++ b/client/lib/application/src/application-detail/placeholder.jsx
@@ -73,6 +73,12 @@ const ApplicationDetailPlaceholder = (props) => {
                             </td>
                         </tr>
                         <tr>
+                            <th>Support</th>
+                            <td className='u-placeholder-text'>
+                                verlongissues
+                            </td>
+                        </tr>
+                        <tr>
                             <th>Specification Type</th>
                             <td className='u-placeholder-text'>
                                 verlongissues

--- a/client/lib/application/src/application-form/application-form.jsx
+++ b/client/lib/application/src/application-form/application-form.jsx
@@ -261,6 +261,19 @@ class ApplicationForm extends React.Component {
                                 type='url' />
                         </div>
                         <div className='form-group'>
+                            <label htmlFor='support_url'>Support</label>
+                            <small>Where you can file for support issues or feature requests. Must be an HTTPS URL or an email address</small>
+                            <input
+                                placeholder='https://github.com/zalando-stups/pierone/issues'
+                                id='support_url'
+                                value={app.support_url}
+                                pattern='((^https:\/\/.*$)|(^[\S]+@[\S]+$))'
+                                title='Please provide a URL with HTTPS or an email address'
+                                onChange={this.update.bind(this, 'support_url', 'value')}
+                                name='yourturn_app_support_url'
+                                type='text' />
+                        </div>
+                        <div className='form-group'>
                             <label htmlFor='documentation_url'>Documentation URL</label>
                             <small>Where your documentation is.
                             The application SHOULD have a link to its documentation.</small>


### PR DESCRIPTION
There is a new `support_url` field in the application schema for a URL
to file for support/feature issues. Add an input, `Support` in the application
details form when creating/updating an application and when displaying
application details
Issue is tracked [here](https://github.bus.zalan.do/pitchfork/issues/issues/13)