### PR TITLE
Added Allowed list endpoint

### DIFF
--- a/server/src/routes/user.js
+++ b/server/src/routes/user.js
@@ -59,8 +59,19 @@ function accounts(req, res) {
         });
 }
 
+/**
+ * @type {import('express').RequestParamHandler}
+ */
+const allowList = function (req, res) {
+  const allowListOfUsers = (process.env.YTENV_RESOURCE_WHITELIST || '')
+    .split(/\s/)
+    .filter(i => !!i);
+  res.status(200).json(allowListOfUsers);
+}
+
 module.exports = {
     accounts,
     detail,
-    teams
+    teams,
+    allowList
 };

--- a/server/src/yourturn.js
+++ b/server/src/yourturn.js
@@ -61,6 +61,7 @@ server.get('/teams/:teamId', routes.team.team);
 server.get('/users/:userId', oauth, uniqueLogins(store), routes.user.detail);
 server.get('/users/:userId/teams', routes.user.teams)
 server.get('/users/:userId/accounts', routes.user.accounts);
+server.get('/allowed-list', routes.user.allowList);
 server.get('/tokeninfo', routes.tokeninfo.info);
 server.get('/metrics', (req, res) => {
     report.generate().then(report => {

--- a/server/src/yourturn.js
+++ b/server/src/yourturn.js
@@ -62,7 +62,7 @@ server.get('/users/:userId', oauth, uniqueLogins(store), routes.user.detail);
 server.get('/users/:userId/teams', routes.user.teams)
 server.get('/users/:userId/accounts', routes.user.accounts);
 server.get('/allowed-list', routes.user.allowList);
-server.get('/tokeninfo', routes.tokeninfo.info);
+server.get('/tokeninfo', oauth, routes.tokeninfo.info);
 server.get('/metrics', (req, res) => {
     report.generate().then(report => {
         res.json(report);

--- a/server/src/yourturn.js
+++ b/server/src/yourturn.js
@@ -61,8 +61,8 @@ server.get('/teams/:teamId', routes.team.team);
 server.get('/users/:userId', oauth, uniqueLogins(store), routes.user.detail);
 server.get('/users/:userId/teams', routes.user.teams)
 server.get('/users/:userId/accounts', routes.user.accounts);
-server.get('/allowed-list', routes.user.allowList);
-server.get('/tokeninfo', oauth, routes.tokeninfo.info);
+server.get('/allowed-list', oauth, routes.user.allowList);
+server.get('/tokeninfo', routes.tokeninfo.info);
 server.get('/metrics', (req, res) => {
     report.generate().then(report => {
         res.json(report);


### PR DESCRIPTION
### Related issue
[pitchfork/issues#567](https://github.bus.zalan.do/pitchfork/issues/issues/567)

### Description
A file is generated every time YourTurn docker pod runs that holds mostly links. However, it also includes a list of whitelisted users which is a vulnerability according to this [Collibra report](https://zalando.collibra.com/asset/ea96f266-88f6-47d7-b7b3-ff3cc95dc7c3).

This PR creates an endpoint that provides the list of whitelisted users behind oauth so it can be concealed from the public. This PR doesn't not have an implementation of the endpoint being used because the solution should be tested beforehand since it pulls this information from node's `process.env` which is supposedly being injected in the pipeline.

Once this PR is merged and tested, I will follow up with another PR to remove the whitelist from the `env.js` and rely on the endpoint.
